### PR TITLE
Confirm email by userId

### DIFF
--- a/src/config/emails.ts
+++ b/src/config/emails.ts
@@ -17,4 +17,4 @@ export const getEmailAuth = function(
   return { username, password };
 };
 
-export const CONFIRM_EMAIL_TOKEN_EXPIRY = 86400000; // 1 day
+export const CONFIRM_EMAIL_TOKEN_EXPIRY = 31557600000; // 1 year

--- a/src/controllers/confirmEmail.ts
+++ b/src/controllers/confirmEmail.ts
@@ -202,3 +202,105 @@ export const resendConfirmationEmail = async (
     next(new createError[500]());
   }
 };
+
+export const confirmEmailById = async function(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): Promise<void> {
+  let ssoUser;
+  let didConfirmSsoUser = false;
+  let wasEncVmtUpdateSuccess = false;
+
+  try {
+    ssoUser = await User.findById(req.body.ssoId);
+
+    if (ssoUser === null) {
+      res.json({
+        isValid: false,
+        info: 'Could not find requested user',
+      });
+      return;
+    }
+
+    if (ssoUser.isEmailConfirmed) {
+      res.json({
+        isValid: false,
+        info: 'Email has already been confirmed',
+      });
+      return;
+    }
+
+    ssoUser.isEmailConfirmed = true;
+    ssoUser.confirmEmailDate = new Date();
+
+    // keep token details on ssoUser in case they try to click link again
+    // should display message saying that their email has already been confirmed
+    // update enc and vmt users
+
+    let { vmtUserId, encUserId } = ssoUser;
+
+    if (isNil(vmtUserId) || isNil(encUserId)) {
+      // should never happen
+      return next(new createError[500]());
+    }
+
+    let {
+      wasSuccess,
+      updatedEncUser,
+      updatedVmtUser,
+    } = await confirmEncVmtEmails(encUserId, vmtUserId);
+
+    if (wasSuccess === false) {
+      // either enc or vmt update failed
+      // revert any changes and return error without confirming
+      // email on ssoUser
+      await unconfirmEncVmtEmails(encUserId, vmtUserId);
+      return next(
+        new createError[500](
+          'Sorry, an unexpected error occurred. Please try again.',
+        ),
+      );
+    }
+    wasEncVmtUpdateSuccess = true;
+    // save ssoUser once vmt and enc have been updated
+    await ssoUser.save();
+    didConfirmSsoUser = true;
+
+    let isVmt = getIssuerNameFromReq(req) === AppNames.Vmt;
+
+    const data = {
+      isValid: true,
+      isEmailConfirmed: ssoUser.isEmailConfirmed,
+      user: isVmt ? updatedVmtUser : updatedEncUser,
+      confirmedEmail: ssoUser.email,
+    };
+
+    res.json(data);
+  } catch (err) {
+    console.log('error confirm email: ', err);
+
+    if (isNil(ssoUser)) {
+      return next(new createError[500]());
+    }
+
+    let doRevert = wasEncVmtUpdateSuccess && !didConfirmSsoUser;
+
+    if (doRevert) {
+      let { vmtUserId, encUserId } = ssoUser;
+
+      if (isNil(vmtUserId) || isNil(encUserId)) {
+        // should never happen
+        return next(new createError[500]());
+      }
+      await unconfirmEncVmtEmails(encUserId, vmtUserId);
+
+      return next(
+        new createError[500](
+          'Sorry, an unexpected error occurred. Please try again.',
+        ),
+      );
+    }
+    next(err);
+  }
+};

--- a/src/db_migration/syncIsEmailConfirmed.ts
+++ b/src/db_migration/syncIsEmailConfirmed.ts
@@ -1,0 +1,82 @@
+import { connect, find } from './utils';
+
+const encDbUri = 'mongodb://localhost:27017/encompass';
+const vmtDbUri = 'mongodb://localhost:27017/vmt';
+const ssoDbUri = 'mongodb://localhost:27017/mtlogin';
+
+async function update(): Promise<void> {
+  let ssoDb = await connect(ssoDbUri);
+  let vmtDb = await connect(vmtDbUri);
+  let encDb = await connect(encDbUri);
+
+  try {
+    let encConfirmedEmailUsers = await find(encDb, 'users', {
+      isEmailConfirmed: true,
+    });
+
+    let missingUsernames: string[] = [];
+    let missingVmtUsernames: string[] = [];
+
+    await Promise.all(
+      encConfirmedEmailUsers.map(
+        async (encUser): Promise<void> => {
+          let ssoUser = await ssoDb
+            .collection('users')
+            .findOne({ _id: encUser.ssoId });
+
+          if (!ssoUser) {
+            console.log('missing sso user!');
+            return;
+          }
+          let isNotConfirmed = !ssoUser.isEmailConfirmed;
+
+          if (isNotConfirmed) {
+            console.log('ssoUser: ', ssoUser, ' missing isEmailConfirmed');
+            missingUsernames.push(ssoUser.username);
+
+            let filter = { _id: ssoUser._id };
+            let update = {
+              $set: { isEmailConfirmed: true, confirmEmailDate: new Date() },
+            };
+            await ssoDb.collection('users').findOneAndUpdate(filter, update);
+          }
+
+          let vmtUser = await vmtDb
+            .collection('users')
+            .findOne({ ssoId: encUser.ssoId });
+
+          if (!vmtUser) {
+            console.log('missing vmt user!');
+            return;
+          }
+          let isVmtNotConfirmed = !vmtUser.isEmailConfirmed;
+
+          if (isVmtNotConfirmed) {
+            console.log('vmtUser: ', vmtUser, ' missing isEmailConfirmed');
+            missingVmtUsernames.push(vmtUser.username);
+
+            let filter = { _id: vmtUser._id };
+            let update = {
+              $set: { isEmailConfirmed: true, confirmEmailDate: new Date() },
+            };
+            await vmtDb.collection('users').findOneAndUpdate(filter, update);
+          }
+        },
+      ),
+    );
+
+    console.log(`Sso users missing email confirmation: ${missingUsernames}`);
+    console.log(`Vmt users missing email confirmation: ${missingVmtUsernames}`);
+
+    ssoDb.close();
+    encDb.close();
+    vmtDb.close();
+  } catch (err) {
+    console.log(err);
+    ssoDb.close();
+    encDb.close();
+    vmtDb.close();
+  }
+}
+
+update();

--- a/src/routes/auth/confirmEmail.ts
+++ b/src/routes/auth/confirmEmail.ts
@@ -2,11 +2,14 @@ import { Router } from 'express';
 const router = Router();
 
 import { validateBasicToken } from '../../validators/base';
+import { validateConfirmEmailByIdRequest } from '../../validators/confirmEmail';
 import {
   confirmEmail,
   resendConfirmationEmail,
+  confirmEmailById,
 } from '../../controllers/confirmEmail';
 export default router;
 
 router.get('/resend', resendConfirmationEmail);
+router.post('/confirm/user', validateConfirmEmailByIdRequest, confirmEmailById);
 router.get('/confirm/:token', validateBasicToken, confirmEmail);

--- a/src/validators/confirmEmail.ts
+++ b/src/validators/confirmEmail.ts
@@ -1,0 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
+
+import { confirmEmailByIdRequest } from './schema';
+import { validatePostRequest } from './base';
+
+export const validateConfirmEmailByIdRequest = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  validatePostRequest(req, res, next, confirmEmailByIdRequest);
+};

--- a/src/validators/schema.ts
+++ b/src/validators/schema.ts
@@ -135,3 +135,7 @@ export const resetPasswordByIdRequest = Joi.object().keys({
   ssoId: ObjectIdHexString.required(),
   password: signupPassword,
 });
+
+export const confirmEmailByIdRequest = Joi.object().keys({
+  ssoId: ObjectIdHexString.required(),
+});


### PR DESCRIPTION
Add route for confirming a user's email by their userId

Currently only used by encompass to manually confirm a user's id
Change confirm email token expiry to 1 day